### PR TITLE
[기타] gitignore에 DS_Store 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 out
 gen
 .gradle
+
+### Delete mac DS.Store files
+.DS_Store


### PR DESCRIPTION
## 문제
mac에서 finder에 접근할 경우, 가끔씩 `.DS_Store`란 파일이 생김. 이건 진짜 쓸데없고 원격에 올라갈 필요도 없는 파일이므로 gitignore에 추가합니다.

<!-- 없음 -->

## 푸는데 걸린 시간
<!-- 없음 -->

## 깨달은 점 (필요한 경우)
<!-- 없음 -->

## 스크린샷 (필요할 경우)
<!-- 없음 -->

## 관련 문서 링크 (필요할 경우)
참고: https://jonhyuk0922.tistory.com/116
